### PR TITLE
Index Page for Articles + Tests / Stories 

### DIFF
--- a/frontend/src/main/components/Articles/ArticlesTable.js
+++ b/frontend/src/main/components/Articles/ArticlesTable.js
@@ -36,23 +36,23 @@ export default function ArticlesTable({ articles, currentUser }) {
       accessor: "id", // accessor is the "key" in the data
     },
     {
-      Header: "title",
+      Header: "Title",
       accessor: "title",
     },
     {
-      Header: "url",
+      Header: "Url",
       accessor: "url",
     },
     {
-      Header: "explanation",
+      Header: "Explanation",
       accessor: "explanation",
     },
     {
-      Header: "email",
+      Header: "Email",
       accessor: "email",
     },
     {
-      Header: "dateAdded",
+      Header: "DateAdded",
       accessor: "dateAdded",
     },
   ];

--- a/frontend/src/main/components/Articles/ArticlesTable.js
+++ b/frontend/src/main/components/Articles/ArticlesTable.js
@@ -5,7 +5,7 @@ import { useBackendMutation } from "main/utils/useBackend";
 import {
   cellToAxiosParamsDelete,
   onDeleteSuccess,
-} from "main/utils/UCSBDateUtils";
+} from "main/utils/articleUtils";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
@@ -36,23 +36,23 @@ export default function ArticlesTable({ articles, currentUser }) {
       accessor: "id", // accessor is the "key" in the data
     },
     {
-      Header: "Title",
+      Header: "title",
       accessor: "title",
     },
     {
-      Header: "Url",
+      Header: "url",
       accessor: "url",
     },
     {
-      Header: "Explanation",
+      Header: "explanation",
       accessor: "explanation",
     },
     {
-      Header: "Email",
+      Header: "email",
       accessor: "email",
     },
     {
-      Header: "DateAdded",
+      Header: "dateAdded",
       accessor: "dateAdded",
     },
   ];

--- a/frontend/src/main/pages/Articles/ArticlesIndexPage.js
+++ b/frontend/src/main/pages/Articles/ArticlesIndexPage.js
@@ -1,17 +1,45 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Button } from "react-bootstrap";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import ArticlesTable from "main/components/Articles/ArticlesTable";
 
 export default function ArticlesIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/articles/create"
+          style={{ float: "right" }}
+        >
+          Create Article
+        </Button>
+      );
+    }
+  };
+
+  const {
+    data: articles,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/articles/all"],
+    { method: "GET", url: "/api/articles/all" },
+    [],
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/articles/create">Create</a>
-        </p>
-        <p>
-          <a href="/articles/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Articles</h1>
+        <ArticlesTable articles={articles} currentUser={currentUser} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/utils/articleUtils.js
+++ b/frontend/src/main/utils/articleUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/articles",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/stories/pages/Articles/ArticlesIndexPage.stories.js
+++ b/frontend/src/stories/pages/Articles/ArticlesIndexPage.stories.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+
+export default {
+  title: "pages/Articles/ArticlesIndexPage",
+  component: ArticlesIndexPage,
+};
+
+const Template = () => <ArticlesIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/articles/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/articles/all", () => {
+      return HttpResponse.json(articlesFixtures.threeArticles);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/articles/all", () => {
+      return HttpResponse.json(articlesFixtures.threeArticles);
+    }),
+    http.delete("/api/articles", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Articles/ArticlesTable.test.js
+++ b/frontend/src/tests/components/Articles/ArticlesTable.test.js
@@ -33,11 +33,11 @@ describe("UserTable tests", () => {
 
     const expectedHeaders = [
       "id",
-      "Title",
-      "Url",
-      "Explanation",
-      "Email",
-      "DateAdded",
+      "title",
+      "url",
+      "explanation",
+      "email",
+      "dateAdded",
     ];
     const expectedFields = [
       "id",
@@ -93,11 +93,11 @@ describe("UserTable tests", () => {
 
     const expectedHeaders = [
       "id",
-      "Title",
-      "Url",
-      "Explanation",
-      "Email",
-      "DateAdded",
+      "title",
+      "url",
+      "explanation",
+      "email",
+      "dateAdded",
     ];
     const expectedFields = [
       "id",

--- a/frontend/src/tests/components/Articles/ArticlesTable.test.js
+++ b/frontend/src/tests/components/Articles/ArticlesTable.test.js
@@ -33,11 +33,11 @@ describe("UserTable tests", () => {
 
     const expectedHeaders = [
       "id",
-      "title",
-      "url",
-      "explanation",
-      "email",
-      "dateAdded",
+      "Title",
+      "Url",
+      "Explanation",
+      "Email",
+      "DateAdded",
     ];
     const expectedFields = [
       "id",
@@ -93,11 +93,11 @@ describe("UserTable tests", () => {
 
     const expectedHeaders = [
       "id",
-      "title",
-      "url",
-      "explanation",
-      "email",
-      "dateAdded",
+      "Title",
+      "Url",
+      "Explanation",
+      "Email",
+      "DateAdded",
     ];
     const expectedFields = [
       "id",

--- a/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.js
@@ -1,5 +1,4 @@
-import { render, screen } from "@testing-library/react";
-import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -7,9 +6,24 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
 
 describe("ArticlesIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "ArticlesTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,14 +36,24 @@ describe("ArticlesIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
 
-    setupUserOnly();
+  test("Renders with Create Button for admin user", async () => {
+    // arrange
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/articles/all").reply(200, []);
 
     // act
-
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,13 +62,123 @@ describe("ArticlesIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    // assert
+    await waitFor(() => {
+      expect(screen.getByText(/Create Article/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create Article/);
+    expect(button).toHaveAttribute("href", "/articles/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three articles correctly for regular user", async () => {
+    // arrange
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/articles/all")
+      .reply(200, articlesFixtures.threeArticles);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
     // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    // assert that the Create button is not present when user isn't an admin
+    expect(screen.queryByText(/Create Article/)).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    // arrange
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/articles/all").timeout();
+    const restoreConsole = mockConsole();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/articles/all",
+    );
+    restoreConsole();
+
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    // arrange
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/articles/all")
+      .reply(200, articlesFixtures.threeArticles);
+    axiosMock
+      .onDelete("/api/articles")
+      .reply(200, "Article with id 1 was deleted");
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act
+    fireEvent.click(deleteButton);
+
+    // assert
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("Article with id 1 was deleted");
+    });
   });
 });


### PR DESCRIPTION
Closes #59 

Added an index page for articles (and tests and stories) that allows the user to interact with the Articles table in our application. The user can now create a new row, delete a row, and edit a row. I also had to add an articleUtils.js file to help deal with a delete bug I was running into. 

Added the following files for this issue: 
- ArticlesIndexPage.js
- ArticlesIndexPage.test.js
- ArticlesIndexPage.stories.js
- articleUtils.js

The code passes all mutation tests and local test



